### PR TITLE
MOBINFRA-2557 - Add a new Github Actions workflow to generate and upload the XCframework on S3 bucket for the Swift Package target #255

### DIFF
--- a/.github/workflows/build_swift_package.yml
+++ b/.github/workflows/build_swift_package.yml
@@ -1,0 +1,21 @@
+name: Building the Swift Package
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Building the Swift Package
+    runs-on: macOS-11
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
+      HOMEBREW_NO_AUTO_UPDATE: 1
+
+    steps:
+     - uses: actions/checkout@v2
+     - uses: webfactory/ssh-agent@v0.4.1
+       with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+     - name: swift build
+       run: swift build -Xswiftc "-sdk" -Xswiftc "`xcrun --sdk iphonesimulator --show-sdk-path`" -Xswiftc "-target" -Xswiftc "x86_64-apple-ios14.0-simulator"

--- a/.github/workflows/release-xcframework.yml
+++ b/.github/workflows/release-xcframework.yml
@@ -1,0 +1,42 @@
+name: Release XCFramework
+on:
+  pull_request:
+    types: [ labeled ]
+  push:
+    tags:
+      - '*'
+
+jobs:
+  release_xcframework:
+    name: Release XCFramework
+    if: ${{ (github.event.number > 0 && github.event.label.name == 'Release XCFramework') || github.event.number == 0 }}
+    runs-on: macos-11
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_12.5.1.app/Contents/Developer
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      xcframeworks_output_path: 'outputs/xcframeworks'
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+      - uses: webfactory/ssh-agent@v0.5.2
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Create XCFrameworks
+        uses: mohamed-3amer/swift-create-xcframework@main
+        with:
+          target: 'ParallaxPagerView'
+          zip-version: ${{ github.event.number == 0 && github.ref_name || format('{0}-pr', github.event.number) }}
+          zip-checksum-output-path: ${{ env.xcframeworks_output_path }}
+          upload-to-artifacts: false
+
+      - name: Upload XCFrameworks to S3
+        uses: shallwefootball/upload-s3-action@v1.1.3
+        with:
+           aws_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
+           aws_bucket: 'pd-ios-spm-binaries'
+           source_dir: ${{ env.xcframeworks_output_path }}
+           destination_dir: 'ParallaxPagerView'


### PR DESCRIPTION
Jira Link
-
[MOBINFRA-2557](https://jira.deliveryhero.com/browse/MOBINFRA-2557)

Type of change
-
New feature

What's the purpose of this PR?
-
**Same like this PR(https://github.com/deliveryhero/pd-kami/pull/59)**
- Add a new Github Actions workflow to generate and upload the XCframework on the S3 bucket for the Swift package target.
- The workflow will be triggered on:
     1 . New tags and will use the tag number as a postfix for the output files.
     2. Pull request labeled by `Release XCFramework` label. XCFramework name will be TARGET_NAME-PR_Number-PR.
- I forked the `https://github.com/philprime/swift-create-xcframework` repo to `Add zip-version`, `zip-checksum-output-path`, and `upload-to-artifacts` action inputs to configure saving the zip files locally and uploading to Github artifacts

What is the impact of this change?
-
New Github Actions workflow on tags and Release XCFramework PR label has been added.