### PR TITLE
use Bundle._module instead of Bundle(identifier:)

### DIFF
--- a/ParallaxPagerView.xcodeproj/project.pbxproj
+++ b/ParallaxPagerView.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		E23C7FE2215D3C33005F2545 /* ParallaxPagerView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* ParallaxPagerView.framework */; };
 		E23C7FE3215D3C33005F2545 /* ParallaxPagerView.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 52D6D97C1BEFF229002C0205 /* ParallaxPagerView.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E23C7FE8215D3E0B005F2545 /* photo.jpg in Resources */ = {isa = PBXBuildFile; fileRef = E23C7FE7215D3E0B005F2545 /* photo.jpg */; };
+		E6C4894D281198210098DBE5 /* Bundle+module.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C4894C281198210098DBE5 /* Bundle+module.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,7 @@
 		E23C7FD7215D3A96005F2545 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E23C7FDB215D3B0B005F2545 /* DemoTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DemoTableViewController.swift; sourceTree = "<group>"; };
 		E23C7FE7215D3E0B005F2545 /* photo.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = photo.jpg; sourceTree = "<group>"; };
+		E6C4894C281198210098DBE5 /* Bundle+module.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+module.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 			isa = PBXGroup;
 			children = (
 				B0B7E83A2772203F009E3000 /* Tabs */,
+				E6C4894B281198010098DBE5 /* Extensions */,
 				B0B7E83D2772203F009E3000 /* ParallaxPagerView.swift */,
 				B0B7E83E2772203F009E3000 /* TabsConfig.swift */,
 				B0B7E83F2772203F009E3000 /* Protocols.swift */,
@@ -141,6 +144,14 @@
 				E23C7FD7215D3A96005F2545 /* Info.plist */,
 			);
 			path = Example;
+			sourceTree = "<group>";
+		};
+		E6C4894B281198010098DBE5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				E6C4894C281198210098DBE5 /* Bundle+module.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -261,6 +272,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B0B7E8422772203F009E3000 /* TabsView.swift in Sources */,
+				E6C4894D281198210098DBE5 /* Bundle+module.swift in Sources */,
 				B0B7E8452772203F009E3000 /* TabsConfig.swift in Sources */,
 				B0B7E8442772203F009E3000 /* ParallaxPagerView.swift in Sources */,
 				B0B7E8462772203F009E3000 /* Protocols.swift in Sources */,

--- a/Sources/ParallaxPagerView/Extensions/Bundle+module.swift
+++ b/Sources/ParallaxPagerView/Extensions/Bundle+module.swift
@@ -1,0 +1,21 @@
+// Copyright © 2022 Delivery Hero. All rights reserved.
+
+import Foundation
+
+final class BundleToken {}
+
+extension Foundation.Bundle {
+  // NOTE: Can not use the `Bundle.module` right now because the b2c
+  // still using ParallaxPagerView as a Carthage dependency, so we have to
+  // support 2 kinds of source dependencies managements. Pls, switch
+  // to `Bundle.module` when we already removed the Carthage in b2c.
+  
+  // swiftlint:disable:next variable_name
+  static var _module: Bundle = {
+#if SWIFT_PACKAGE
+    return Bundle.module
+#else
+    return Bundle(for: BundleToken.self)
+#endif
+  }()
+}

--- a/Sources/ParallaxPagerView/Tabs/TabsView.swift
+++ b/Sources/ParallaxPagerView/Tabs/TabsView.swift
@@ -80,8 +80,8 @@ public class TabsView: UIView {
 
   public static func tabsView(with config: TabsConfig) -> TabsView {
 
-    let bundle = Bundle(identifier: "com.ParallaxPagerView.ParallaxPagerView-iOS")
-    let tabsView = bundle!.loadNibNamed("TabsView", owner: nil, options: nil)?.first as! TabsView
+    let bundle = Bundle._module
+    let tabsView = bundle.loadNibNamed("TabsView", owner: nil, options: nil)?.first as! TabsView
     tabsView.tabsConfig = config
     tabsView.frame = CGRect(x: 0, y: 0, width: tabsView.frame.size.width, height: config.height)
     tabsView.createTabs()


### PR DESCRIPTION
What is the purpose of this PR
-
Use Bundle._module property which checks if used as a swift package it resolves to Bundle.module otherwise uses Bundle(for:) initialiser as currently used Bundle(identifier:) causes crashes when used from Volo

What is the impact of this PR
-
Using Parallax Pager View from Volo using SPM wouldn't cause any crashes